### PR TITLE
Add functions to process recount2 template and compendium data

### DIFF
--- a/generic_expression_patterns_modules/process.py
+++ b/generic_expression_patterns_modules/process.py
@@ -509,17 +509,19 @@ def get_renamed_columns(
 ):
     """
     Find the new column names and corresponding column indexes.
-    Returns a tuple that includes two entries. The first entry is a list
-    of hgnc gene symbols (which will be the new column names in remapped
-    recount2 data file; The second entry is a dict whose keys are hgnc gene
-    symbols and values are lists of the corresponding indexes of columns in
-    the raw recount2 data file (most lists include only one column index.)
 
     Arguments:
     - raw_ensembl_ids: list of strings (ensembl gene IDs), which are columns
                        names in raw recount2 data file;
     - merged_gene_id_mapping: DataFrame of merged gene ID mapping;
     - manual_mapping: dict of manual mapping (key: ensembl_id, value: gene symbol)
+
+    Returns a tuple that includes two entries. The first entry is a list
+    of hgnc gene symbols (which will be the new column names in remapped
+    recount2 data file; The second entry is a dict whose keys are hgnc gene
+    symbols and values are lists of the corresponding indexes of columns in
+    the raw recount2 data file (most lists include only one column index.)
+
     """
 
     updated_mapping = merged_gene_id_mapping.loc[


### PR DESCRIPTION
This PR adds a few functions to process recount2 template and compendium data. Most logics are copied from
https://github.com/greenelab/generic-expression-patterns/blob/master/human_analysis/1_process_recount2_data.ipynb

Here is an example to run these functions:
```python
# input files (assume they already exist)
raw_filename = "raw_template.tsv"
gene_id_filename = "ensembl_hgnc_mapping.tsv"
DE_prior_filename = "https://raw.githubusercontent.com/maggiecrow/DEprior/master/DE_Prior.txt"
sample_id_metadata_filename = "sample_id_meta.tsv"

# User's own gene mapping, which overrides all other mappings
manual_mapping = {
    "ENSG00000187510.7": "PLEKHG7",    # not necessary (available in latest gene_id_mapping)
    "ENSG00000230417.11": "LINC00595", # not necessary (1st of duplicates)
    "ENSG00000276085.1": "CCL3L1",     # not necessary (1st of duplicates)
    "ENSG00000255374.3": "TAS2R45",    # NEEDED        (2nd of duplicates)
}

# Output files
mapped_filename = "mapped_temp.tsv"
processed_filename = "processed_temp.tsv"

# Process recount2 template
process.process_raw_template(
    raw_filename,
    gene_id_filename,
    manual_mapping,
    DE_prior_filename,
    mapped_filename,
    sample_id_metadata_filename,
    processed_filename
)
```

                                                                                                    
